### PR TITLE
Adjust wheel base from 12cm to 10cm for stepper cube robot

### DIFF
--- a/Agent_Robot_Model/Readme.md
+++ b/Agent_Robot_Model/Readme.md
@@ -102,7 +102,7 @@
 |-----------|-------|
 | Wheel diameter | 6.0 cm |
 | Wheel circumference | 18.85 cm |
-| Wheel base | 12.0 cm |
+| Wheel base | 10.0 cm |
 | Steps per cm | ~217.3 |
 | Max speed | 1024 steps/s (~4.71 cm/s) |
 | Max acceleration | 512 steps/s² |

--- a/NEXT_STEPS_POC.md
+++ b/NEXT_STEPS_POC.md
@@ -557,7 +557,7 @@ The LLMos codebase now includes a complete hardware specification — officially
 
 1. **3D print the "Stepper Cube" chassis** from `Agent_Robot_Model/Robot_one/`. The 8cm cube mounts the ESP32s, ULN2003 drivers, and motors.
 2. **Mount the rear ball caster** — stepper motors have low torque, so reducing friction prevents wheel slip (which ruins dead-reckoning).
-3. **Verify wheel dimensions** — the codebase hardcodes 6.0 cm wheel diameter (18.85 cm circumference) and 12.0 cm wheel base. If your wheels differ, use `{"cmd":"set_config","wheel_diameter_cm":F,"wheel_base_cm":F}` to calibrate.
+3. **Verify wheel dimensions** — the codebase hardcodes 6.0 cm wheel diameter (18.85 cm circumference) and 10.0 cm wheel base. If your wheels differ, use `{"cmd":"set_config","wheel_diameter_cm":F,"wheel_base_cm":F}` to calibrate.
 
 ### 6.2 Communication Protocol Deployment
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The **V1 Stepper Cube** — an 8cm 3D-printed cube with everything inside:
 | **ESP32-CAM (AI-Thinker)** | Camera | Streams MJPEG at 320x240 @ 10fps over HTTP |
 | **2x 28BYJ-48** | Stepper motors | 4096 steps/rev, ~217 steps/cm, max ~4.7 cm/s |
 | **2x ULN2003** | Motor drivers | Darlington arrays driving the steppers |
-| **6cm wheels** | Locomotion | 12cm wheel base, differential drive |
+| **6cm wheels** | Locomotion | 10cm wheel base, differential drive |
 | **Ball caster** | Rear support | Low friction — critical for rotation accuracy |
 | **5V 2A USB-C** | Power | Powers both ESP32s and both motors |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -227,7 +227,7 @@ gantt
 - [ ] 3D print the 8cm cube chassis from `Agent_Robot_Model/Robot_one/`
 - [ ] Mount ESP32-S3, ESP32-CAM, ULN2003 drivers, 28BYJ-48 motors
 - [ ] Install rear ball caster for low-friction third contact point
-- [ ] Verify wheel dimensions match codebase constants (6cm diameter, 12cm wheel base)
+- [ ] Verify wheel dimensions match codebase constants (6cm diameter, 10cm wheel base)
 - [ ] If wheels differ, calibrate via `{"cmd":"set_config","wheel_diameter_cm":F,"wheel_base_cm":F}`
 
 #### Step 2: Communication Protocol Validation

--- a/__tests__/lib/hal/stepper-kinematics.test.ts
+++ b/__tests__/lib/hal/stepper-kinematics.test.ts
@@ -18,7 +18,7 @@ describe('StepperKinematics', () => {
     const spec = kin.getSpec();
     expect(spec.stepsPerRevolution).toBe(4096);
     expect(spec.wheelDiameterCm).toBe(6.0);
-    expect(spec.wheelBaseCm).toBe(12.0);
+    expect(spec.wheelBaseCm).toBe(10.0);
     expect(spec.maxStepsPerSecond).toBe(1024);
     expect(spec.maxAcceleration).toBe(512);
   });
@@ -74,9 +74,9 @@ describe('StepperKinematics', () => {
   // ===========================================================================
 
   test('360 degree rotation uses correct arc length', () => {
-    // Arc for 360° in-place rotation: PI * wheelBase = PI * 12 ≈ 37.7 cm
+    // Arc for 360° in-place rotation: PI * wheelBase = PI * 10 ≈ 31.4 cm
     const steps = kin.rotationToSteps(360);
-    const expectedArcCm = Math.PI * 12;
+    const expectedArcCm = Math.PI * 10;
     const expectedSteps = Math.round(expectedArcCm * kin.getStepsPerCm());
     expect(steps).toBe(expectedSteps);
   });

--- a/components/applets/system-applets.ts
+++ b/components/applets/system-applets.ts
@@ -1212,7 +1212,7 @@ void update(void) {
     const simulatePhysics = () => {
       const dt = 0.05;
       const SPEED_SCALE = 0.008;
-      const WHEEL_BASE = 0.15;
+      const WHEEL_BASE = 0.10;
       const vL = motors.left * SPEED_SCALE;
       const vR = motors.right * SPEED_SCALE;
       const v = (vR + vL) / 2.0;

--- a/docs/07-hal-and-hardware.md
+++ b/docs/07-hal-and-hardware.md
@@ -325,7 +325,7 @@ The reference hardware platform is the **Robot V1 -- Stepper Cube Robot**, an 8c
 | Camera | ESP32-CAM (AI-Thinker), OV2640, MJPEG streaming |
 | Motors | 2x 28BYJ-48 stepper (5V unipolar, 4096 steps/rev, 64:1 gear ratio) |
 | Drivers | 2x ULN2003 Darlington arrays |
-| Wheels | 6cm diameter, 12cm wheel base |
+| Wheels | 6cm diameter, 10cm wheel base |
 | Support | Rear ball caster (low friction for stepper torque) |
 | Power | 5V 2A USB-C |
 | Chassis | 8cm 3D-printed cube from `Agent_Robot_Model/Robot_one/` |
@@ -361,8 +361,8 @@ calculateMoveDuration()    // trapezoidal motion profile
 ```
 
 The `rotationToSteps` function computes the arc length each wheel must travel for an
-in-place rotation. For a 90-degree turn with a 12cm wheel base, each wheel travels
-`pi * 12 / 4 = 9.42 cm` in opposite directions, which is `9.42 * 217.3 = 2047 steps`.
+in-place rotation. For a 90-degree turn with a 10cm wheel base, each wheel travels
+`pi * 10 / 4 = 7.85 cm` in opposite directions, which is `7.85 * 217.3 = 1706 steps`.
 If the calibrated wheel dimensions differ from the codebase defaults, the
 `set_config` command updates the firmware constants.
 

--- a/docs/14-whats-next.md
+++ b/docs/14-whats-next.md
@@ -85,7 +85,7 @@ the `.stl` / `.blend` files, the LLM will hallucinate its location in space.
 - Mount the rear ball caster (stepper motors have low torque; reducing friction
   prevents wheel slip)
 - Verify wheel dimensions match the codebase: 6.0 cm wheel diameter (18.85 cm
-  circumference), 12.0 cm wheel base
+  circumference), 10.0 cm wheel base
 - If wheels differ, calibrate with:
   `{"cmd":"set_config","wheel_diameter_cm":F,"wheel_base_cm":F}`
 

--- a/firmware/esp32-s3-stepper/esp32-s3-stepper.ino
+++ b/firmware/esp32-s3-stepper/esp32-s3-stepper.ino
@@ -9,7 +9,7 @@
  *   - ESP32-S3-DevKitC-1
  *   - 2x 28BYJ-48 (4096 steps/rev, 64:1 gear ratio)
  *   - 2x ULN2003 driver boards
- *   - 6cm diameter wheels, 12cm wheel base
+ *   - 6cm diameter wheels, 10cm wheel base
  *
  * Protocol: JSON over UDP port 4210
  * Commands: move_steps, move_cm, rotate_deg, stop, get_status, set_config
@@ -53,7 +53,7 @@ const int UDP_PORT = 4210;
 
 #define STEPS_PER_REV      4096    // 64:1 gear ratio * 64 steps
 #define WHEEL_DIAMETER_CM  6.0f
-#define WHEEL_BASE_CM      12.0f
+#define WHEEL_BASE_CM      10.0f
 #define MAX_SPEED_STEPS_S  1024    // Safe max for 28BYJ-48
 #define DEFAULT_ACCEL      512     // steps/s^2
 

--- a/lib/hal/stepper-kinematics.ts
+++ b/lib/hal/stepper-kinematics.ts
@@ -8,7 +8,7 @@
  *   - 4096 steps/rev (64:1 gear ratio)
  *   - ~15 RPM max
  *   - 6cm diameter wheels
- *   - 12cm wheel base
+ *   - 10cm wheel base
  */
 
 // =============================================================================
@@ -40,7 +40,7 @@ export interface ArcSpeeds {
 export const DEFAULT_28BYJ48_SPEC: StepperMotorSpec = {
   stepsPerRevolution: 4096,
   wheelDiameterCm: 6.0,
-  wheelBaseCm: 12.0,
+  wheelBaseCm: 10.0,
   maxStepsPerSecond: 1024,
   maxAcceleration: 512,
 };

--- a/lib/hardware/cube-robot-simulator.ts
+++ b/lib/hardware/cube-robot-simulator.ts
@@ -55,7 +55,7 @@ export const ROBOT_SPECS_V1_STEPPER = {
   // Physical dimensions (meters)
   BODY_SIZE: 0.08,           // 8cm cube (same chassis)
   WHEEL_RADIUS: 0.03,        // 3cm (6cm diameter wheels)
-  WHEEL_BASE: 0.12,          // 12cm between wheels
+  WHEEL_BASE: 0.10,          // 10cm between wheels
   WHEEL_WIDTH: 0.01,         // 1cm wheel width
 
   // Stepper motor specs (28BYJ-48)

--- a/lib/runtime/robot4-runtime.ts
+++ b/lib/runtime/robot4-runtime.ts
@@ -107,7 +107,7 @@ export class Robot4Runtime {
   private encoders = { left: 0, right: 0 };
 
   // Robot physical constants
-  private readonly WHEEL_BASE = 0.15;      // 15cm between wheels
+  private readonly WHEEL_BASE = 0.10;      // 10cm between wheels
   private readonly WHEEL_RADIUS = 0.0325;  // 32.5mm wheel radius
   private readonly TICKS_PER_REV = 360;    // Encoder resolution
   private readonly MAX_SPEED = 1.0;        // m/s at PWM 255

--- a/public/volumes/system/skills/esp32-cube-robot.md
+++ b/public/volumes/system/skills/esp32-cube-robot.md
@@ -17,7 +17,7 @@ When controlling or simulating a two-wheeled differential drive cube robot based
 |-----------|-------------|
 | MCU | ESP32-S3 |
 | Drive System | Differential (Left/Right motors) |
-| Wheel Base | 0.5 meters (distance between wheels) |
+| Wheel Base | 0.10 meters (distance between wheels) |
 | Sensors | Front Camera, Wheel Encoders |
 | Protocol | JSON over Serial (115200 baud) |
 | Motor Range | -255 (full reverse) to 255 (full forward) |

--- a/volumes/system/skills/esp32-cube-robot.md
+++ b/volumes/system/skills/esp32-cube-robot.md
@@ -263,7 +263,7 @@ The V1 hardware replaces DC motors with 28BYJ-48 steppers and USB serial with Wi
 | ESP32-S3-DevKitC-1 | WiFi motor controller |
 | ESP32-CAM (AI-Thinker) | WiFi camera (MJPEG streaming) |
 | 2x 28BYJ-48 + ULN2003 | Stepper motors with drivers |
-| 6cm wheels, 12cm wheel base | Differential drive |
+| 6cm wheels, 10cm wheel base | Differential drive |
 
 ### WiFi UDP Command Protocol (Port 4210)
 
@@ -286,7 +286,7 @@ Replaces the serial JSON protocol with UDP JSON for lower latency:
 {"cmd":"get_status"}
 
 // Update calibration
-{"cmd":"set_config", "wheel_diameter_cm":6.0, "wheel_base_cm":12.0}
+{"cmd":"set_config", "wheel_diameter_cm":6.0, "wheel_base_cm":10.0}
 ```
 
 ### Camera Streaming Setup

--- a/volumes/system/skills/stepper-movement-primitives.md
+++ b/volumes/system/skills/stepper-movement-primitives.md
@@ -36,7 +36,7 @@ steps = distance_cm × STEPS_PER_CM
 ### Rotation to Steps (In-Place Turn)
 ```
 ARC_CM = (degrees / 360) × π × WHEEL_BASE
-       = (degrees / 360) × π × 12.0
+       = (degrees / 360) × π × 10.0
 
 left_steps  = +ARC_CM × STEPS_PER_CM   (forward)
 right_steps = -ARC_CM × STEPS_PER_CM   (backward)
@@ -100,8 +100,8 @@ Backward 10cm: left=-2173 steps, right=-2173 steps
 
 ### Point Turn (Rotate in Place)
 ```
-Turn right 90°:  left=+1664 steps, right=-1664 steps
-Turn left 90°:   left=-1664 steps, right=+1664 steps
+Turn right 90°:  left=+1707 steps, right=-1707 steps
+Turn left 90°:   left=-1707 steps, right=+1707 steps
 ```
 
 ### Arc Turn


### PR DESCRIPTION
## Summary
Updates the wheel base specification for the V1 Stepper Cube Robot from 12cm to 10cm across all firmware, kinematics, documentation, and simulation code. This reflects the actual physical dimensions of the assembled robot.

## Key Changes
- **Firmware**: Updated `WHEEL_BASE_CM` constant from 12.0f to 10.0f in ESP32-S3 stepper controller
- **Kinematics**: Modified `DEFAULT_28BYJ48_SPEC.wheelBaseCm` from 12.0 to 10.0 in stepper kinematics library
- **Tests**: Updated rotation kinematics test expectations (360° rotation arc from 37.7cm to 31.4cm)
- **Simulators**: Adjusted wheel base in both cube robot simulator (0.12m → 0.10m) and robot4 runtime (0.15m → 0.10m)
- **Documentation**: Updated all references across hardware specs, skill documentation, README, roadmap, and deployment guides

## Implementation Details
- The wheel base change affects rotation calculations: for a 90° turn, each wheel now travels `π × 10 / 4 = 7.85 cm` (1707 steps) instead of 9.42 cm (2047 steps)
- All kinematics calculations remain consistent—only the base constant changed
- Simulator physics and runtime constants updated to match actual hardware dimensions
- Documentation examples and calibration references updated for consistency

https://claude.ai/code/session_018SnyAV8Zc2SsVBvKtKeKtf